### PR TITLE
Fix system info menu fallback

### DIFF
--- a/ScriptManager.bat
+++ b/ScriptManager.bat
@@ -276,20 +276,27 @@ echo ================================================================
 echo.
 echo Computer Name: %COMPUTERNAME%
 echo User Name: %USERNAME%
-echo OS Version: 
+echo OS Version:
 ver
 echo.
-echo Processor:
-wmic cpu get name /value | findstr "Name="
-echo.
-echo Memory:
-wmic computersystem get TotalPhysicalMemory /value | findstr "TotalPhysicalMemory="
-echo.
-echo Disk Space:
-wmic logicaldisk get size,freespace,caption /value | findstr "="
-echo.
-echo Network Adapters:
-wmic path win32_NetworkAdapter where NetEnabled=true get Name /value | findstr "Name="
+where wmic >nul 2>&1
+if %errorlevel%==0 (
+    echo Processor:
+    wmic cpu get name /value | findstr "Name="
+    echo.
+    echo Memory:
+    wmic computersystem get TotalPhysicalMemory /value | findstr "TotalPhysicalMemory="
+    echo.
+    echo Disk Space:
+    wmic logicaldisk get size,freespace,caption /value | findstr "="
+    echo.
+    echo Network Adapters:
+    wmic path win32_NetworkAdapter where NetEnabled=true get Name /value | findstr "Name="
+) else (
+    echo Detailed hardware info not available. Using systeminfo...
+    echo.
+    systeminfo
+)
 echo.
 echo ================================================================
 echo Press any key to continue...


### PR DESCRIPTION
## Summary
- improve system info menu option in `ScriptManager.bat`
- fall back to `systeminfo` when `wmic` is not available

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877f6d19ee0832cb3a0630d0f21cdd2