### PR TITLE
Fix download script names

### DIFF
--- a/ScriptManager.bat
+++ b/ScriptManager.bat
@@ -314,15 +314,15 @@ echo Downloading sample scripts...
 powershell -Command ^
 "& { ^
     $scripts = @{ ^
-        'Clear-BrowserCache.bat' = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Clear%%20Browser%%20Cache%%20and%%20Cookies.bat'; ^
-        'Empty-Downloads.bat'    = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Downloads%%20Folder.bat'; ^
-        'Empty-RecycleBin.ps1'   = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Recycle%%20Bin.ps1'; ^
-        'Reset-WindowsUpdate.bat'= 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Reset%%20Windows%%20Update%%20Cache.bat' ^
+        'Clear Browser Cache and Cookies.bat' = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Clear%%20Browser%%20Cache%%20and%%20Cookies.bat'; ^
+        'Empty Downloads Folder.bat'         = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Downloads%%20Folder.bat'; ^
+        'Empty Recycle Bin.ps1'              = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Recycle%%20Bin.ps1'; ^
+        'Reset Windows Update Cache.bat'     = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Reset%%20Windows%%20Update%%20Cache.bat' ^
     }; ^
     foreach ($script in $scripts.GetEnumerator()) { ^
         try { ^
             $output = Join-Path '%SCRIPT_DIR%' $script.Key; ^
-            Invoke-WebRequest -Uri $script.Value -OutFile $output -UseBasicParsing; ^
+            Invoke-WebRequest -Uri $script.Value -OutFile $output -UseBasicParsing -ErrorAction Stop; ^
             Write-Host \"Downloaded: $($script.Key)\"; ^
         } catch { ^
             Write-Host \"Failed to download: $($script.Key)\"; ^


### PR DESCRIPTION
## Summary
- fetch sample scripts using same filenames as repo
- show failed downloads if web request errors occur

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6877f9c6269c832cb2336dd1ccddd7cb