### PR TITLE
Fix sample script download

### DIFF
--- a/ScriptManager.bat
+++ b/ScriptManager.bat
@@ -310,25 +310,8 @@ if /i not "%download_confirm%"=="y" goto main_menu
 echo.
 echo Downloading sample scripts...
 
-:: Use PowerShell to download scripts
-powershell -Command ^
-"& { ^
-    $scripts = @{ ^
-        'Clear Browser Cache and Cookies.bat' = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Clear%%20Browser%%20Cache%%20and%%20Cookies.bat'; ^
-        'Empty Downloads Folder.bat'         = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Downloads%%20Folder.bat'; ^
-        'Empty Recycle Bin.ps1'              = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%%20Recycle%%20Bin.ps1'; ^
-        'Reset Windows Update Cache.bat'     = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Reset%%20Windows%%20Update%%20Cache.bat' ^
-    }; ^
-    foreach ($script in $scripts.GetEnumerator()) { ^
-        try { ^
-            $output = Join-Path '%SCRIPT_DIR%' $script.Key; ^
-            Invoke-WebRequest -Uri $script.Value -OutFile $output -UseBasicParsing -ErrorAction Stop; ^
-            Write-Host \"Downloaded: $($script.Key)\"; ^
-        } catch { ^
-            Write-Host \"Failed to download: $($script.Key)\"; ^
-        } ^
-    } ^
-}"
+:: Use PowerShell script to download files
+powershell -ExecutionPolicy Bypass -File "%~dp0scripts\download-sample-scripts.ps1" "%SCRIPT_DIR%"
 
 echo.
 echo Download completed.

--- a/scripts/download-sample-scripts.ps1
+++ b/scripts/download-sample-scripts.ps1
@@ -1,0 +1,22 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$ScriptDir
+)
+
+$scripts = @{
+    'Clear Browser Cache and Cookies.bat' = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Clear%20Browser%20Cache%20and%20Cookies.bat'
+    'Empty Downloads Folder.bat'         = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%20Downloads%20Folder.bat'
+    'Empty Recycle Bin.ps1'              = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Empty%20Recycle%20Bin.ps1'
+    'Reset Windows Update Cache.bat'     = 'https://raw.githubusercontent.com/njvanas/AIO-Maintenance/main/scripts/Reset%20Windows%20Update%20Cache.bat'
+}
+
+foreach ($script in $scripts.GetEnumerator()) {
+    try {
+        $output = Join-Path $ScriptDir $script.Key
+        Invoke-WebRequest -Uri $script.Value -OutFile $output -UseBasicParsing -ErrorAction Stop
+        Write-Host "Downloaded: $($script.Key)"
+    }
+    catch {
+        Write-Host "Failed to download: $($script.Key)"
+    }
+}


### PR DESCRIPTION
## Summary
- fix the download scripts option by using an external PowerShell script
- add new `download-sample-scripts.ps1` helper script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877fb98913c832c833f83761de7ca30